### PR TITLE
UC015 - Efetuar Traceroute #35. Falha requests.

### DIFF
--- a/acs2/src/java/dao/EquipamentoDAO.java
+++ b/acs2/src/java/dao/EquipamentoDAO.java
@@ -36,6 +36,7 @@ import model.device.ping.PingRequest;
 import model.device.ping.PingResponse;
 import model.device.portmapping.PortMappingInfo;
 import model.device.pppoe.PPPoECredentialsInfo;
+import model.device.traceroute.TraceRouteRequest;
 import model.device.wifi.WifiInfo;
 import model.device.wifi.WifiInfoSet;
 import motive.hdm.synchdeviceops.NbiSingleDeviceOperationOptions;
@@ -222,6 +223,26 @@ public class EquipamentoDAO {
         }
     }
 
+    public PortMappingInfo traceroute(NbiDeviceData eqp, TraceRouteRequest trace) throws Exception {
+        try {
+            NbiSingleDeviceOperationOptions opt = NbiDecorator.getDeviceOperationOptionsDefault();
+            this.initSynchDeviceOperations();
+
+            String traceStr = JsonUtil.serialize(trace, trace.getClass());
+            List<Object> json = NbiDecorator.getEmptyJson();
+            json.set(0, traceStr);
+
+            StringResponseDTO a = (StringResponseDTO) synch.executeFunction(NbiDecorator.adapter(eqp), NbiDecorator.getEmptyJson(), 9524, opt, 15000, "");
+
+            System.out.println(a.getValue());
+
+            return null;
+        } catch (DeviceOperationException | NBIException | OperationTimeoutException | ProviderException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
     /**
      * Somente parâmetros alteraveis podem ser serializados para essa chamada
      *
@@ -324,7 +345,6 @@ public class EquipamentoDAO {
             System.out.println(o.getDescription());
         }
     }
-
 
     public StringResponseDTO setPortMapping(NbiDeviceData eqp, PortMappingInfo portMappingInfo) {
         try {

--- a/acs2/src/java/model/device/traceroute/TraceRouteRequest.java
+++ b/acs2/src/java/model/device/traceroute/TraceRouteRequest.java
@@ -1,0 +1,82 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package model.device.traceroute;
+
+/**
+ *
+ * @author G0042204
+ */
+public class TraceRouteRequest {
+
+    private String host, numberOfTries, timeout, dataBlockSize, dscp, maxHopCount, ipInterface;
+
+    public TraceRouteRequest(String host) {
+        this.numberOfTries = "3";
+        this.dataBlockSize = "38";
+        this.maxHopCount = "5";
+        this.ipInterface = "Device.IP.Interface.1";
+        this.timeout = "1000";
+        this.dscp = "0";
+        this.host = host;
+    }
+
+    public String getIpInterface() {
+        return ipInterface;
+    }
+
+    public void setIpInterface(String ipInterface) {
+        this.ipInterface = ipInterface;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public String getNumberOfTries() {
+        return numberOfTries;
+    }
+
+    public void setNumberOfTries(String numberOfTries) {
+        this.numberOfTries = numberOfTries;
+    }
+
+    public String getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(String timeout) {
+        this.timeout = timeout;
+    }
+
+    public String getDataBlockSize() {
+        return dataBlockSize;
+    }
+
+    public void setDataBlockSize(String dataBlockSize) {
+        this.dataBlockSize = dataBlockSize;
+    }
+
+    public String getDscp() {
+        return dscp;
+    }
+
+    public void setDscp(String dscp) {
+        this.dscp = dscp;
+    }
+
+    public String getMaxHopCount() {
+        return maxHopCount;
+    }
+
+    public void setMaxHopCount(String maxHopCount) {
+        this.maxHopCount = maxHopCount;
+    }
+
+}

--- a/acs2/test/tests/junit/acao/TracerouteJUnitTest.java
+++ b/acs2/test/tests/junit/acao/TracerouteJUnitTest.java
@@ -1,0 +1,63 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package tests.junit.acao;
+
+import com.alcatel.hdm.service.nbi2.NbiDeviceData;
+import dao.EquipamentoDAO;
+import model.device.traceroute.TraceRouteRequest;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author G0042204
+ */
+public class TracerouteJUnitTest {
+
+    public TracerouteJUnitTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void traceroute() {
+        try {
+            EquipamentoDAO d = new EquipamentoDAO();
+
+            NbiDeviceData eqp;
+
+            eqp = d.findDeviceByGUID(new Long(142014));
+
+            TraceRouteRequest trace = new TraceRouteRequest("www.google.com");
+
+            d.traceroute(eqp, trace);
+
+            assertTrue(true);
+
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            assertTrue(false);
+        }
+    }
+}


### PR DESCRIPTION
Verificar com Eng. com.motive.synchdeviceopsimpl.synchdeviceoperationsnbiservice.DeviceOperationException: status=1, operationId=166466, faultKey=cwmp.fault.8815, faultString=RUNTIME-ERROR: traceroute:null:18:0:com.alcatel.hdm.javascript.WrappedException: Wrapped java.lang.IllegalStateException: Not a JSON Object: null (traceroute#18), faultMsgParams=[tr098_traceroute.js:traceroute, RUNTIME-ERROR: traceroute:null:18:0:com.alcatel.hdm.javascript.WrappedException: Wrapped java.lang.IllegalStateException: Not a JSON Object: null (traceroute#18)]